### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -135,8 +135,8 @@ WorkingDirectory=/opt/rustdesk/amd64
 User=${uname}
 Group=${uname}
 Restart=always
-StandardOutput=append:/var/log/rustdesk/signalserver.log
-StandardError=append:/var/log/rustdesk/signalserver.error
+StandardOutput=append:/var/log/rustdesk-server/signalserver.log
+StandardError=append:/var/log/rustdesk-server/signalserver.error
 # Restart service after 10 seconds if node service crashes
 RestartSec=10
 [Install]
@@ -160,8 +160,8 @@ WorkingDirectory=/opt/rustdesk/amd64
 User=${uname}
 Group=${uname}
 Restart=always
-StandardOutput=append:/var/log/rustdesk/relayserver.log
-StandardError=append:/var/log/rustdesk/relayserver.error
+StandardOutput=append:/var/log/rustdesk-server/relayserver.log
+StandardError=append:/var/log/rustdesk-server/relayserver.error
 # Restart service after 10 seconds if node service crashes
 RestartSec=10
 [Install]


### PR DESCRIPTION
The original log files of the package version of rustdesk are located in this different directory. To enable a seemless switch between package versions and zip using this script it is better to make it the same.

For example I switched from debian packages to this script because the package versions are rewriting the service files erasing the important -k _ option on every update.